### PR TITLE
#44 use AppContext.BaseDirectory as a main util location

### DIFF
--- a/PDFtoPrinter.NetCoreSample/PDFtoPrinter.NetCoreSample.csproj
+++ b/PDFtoPrinter.NetCoreSample/PDFtoPrinter.NetCoreSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PDFtoPrinter/PDFtoPrinter.csproj
+++ b/PDFtoPrinter/PDFtoPrinter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net47;net48;netstandard2.0;net5.0-windows;net6.0-windows;</TargetFrameworks>
+    <TargetFrameworks>net46;net47;net48;netstandard2.0;net5.0-windows;net6.0-windows;net7.0-windows;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Sergey Vishneskiy</Authors>
     <Company>Sergey Vishneskiy</Company>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/svishnevsky/PDFtoPrinter</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>PDF Printing</PackageTags>
-    <PackageReleaseNotes>Prevent JS running</PackageReleaseNotes>
+    <PackageReleaseNotes>Add dotnet 7 support.</PackageReleaseNotes>
     <PackageId>PDFtoPrinter</PackageId>
     <RootNamespace>PDFtoPrinter</RootNamespace>
     <AssemblyName>PDFtoPrinter</AssemblyName>

--- a/PDFtoPrinter/PDFtoPrinterPrinter.cs
+++ b/PDFtoPrinter/PDFtoPrinterPrinter.cs
@@ -87,10 +87,14 @@ namespace PDFtoPrinter
 
         private static string GetUtilPath(string utilName)
         {
-            return Path.Combine(
-                Path.GetDirectoryName(
-                    (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).Location),
-                utilName);
+            // Fallback logic is required to support all CLR versions.
+            string utilLocation = Path.Combine(AppContext.BaseDirectory, utilName);
+
+            return File.Exists(utilLocation)
+                ? utilLocation
+                : Path.Combine(
+                    Path.GetDirectoryName((Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).Location),
+                    utilName);
         }
     }
 }

--- a/tests/PDFtoPrinter.Tests/PDFtoPrinter.Tests.csproj
+++ b/tests/PDFtoPrinter.Tests/PDFtoPrinter.Tests.csproj
@@ -58,13 +58,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.18.1</Version>
+      <Version>4.18.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.2.10</Version>
+      <Version>3.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.2.10</Version>
+      <Version>3.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />


### PR DESCRIPTION
use AppContext.BaseDirectory as a main util location and keep Assembly.Get*Assembly as a fallback